### PR TITLE
Add OCEL 2.0 mapping UI (phases 1-5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "concurrently": "^8.2.2",
     "date-fns": "^3.6.0",
     "dayjs": "^1.11.11",
-    "ethers": "^6.16.0",
     "graphology": "^0.26.0",
     "graphology-generators": "^0.11.2",
     "graphology-layout": "^0.6.1",
@@ -44,15 +43,13 @@
     "react-graph-vis": "^1.0.7",
     "react-query": "^3.39.3",
     "react-router": "^7.6.0",
-    "react-spinners": "^0.17.0",
     "react-xml-viewer": "^2.0.5",
     "recharts": "^3.1.0",
     "rollup": "^4.52.4",
     "sigma": "^3.0.1",
     "vis-data": "^7.1.9",
     "vis-network": "^9.1.9",
-    "web-vitals": "^2.1.4",
-    "web3": "^4.16.0"
+    "web-vitals": "^2.1.4"
   },
   "scripts": {
     "test": "react-scripts test",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,8 +14,6 @@ import { DialogsProvider } from "@toolpad/core/useDialogs";
 import { QueryClient, QueryClientProvider } from "react-query";
 import StorageIcon from "@mui/icons-material/Storage";
 import FactCheckIcon from '@mui/icons-material/FactCheck';
-import FileCopyIcon from '@mui/icons-material/FileCopy';
-import WaterIcon from '@mui/icons-material/Water';
 
 const NAVIGATION = [
 	{
@@ -40,17 +38,7 @@ const NAVIGATION = [
                 segment: "extractionInternal",
                 title: "Data Extraction Internal",
                 icon: <StorageIcon />,
-            },
-			{
-				segment: "simulation",
-				title: "Simulation",
-				icon: <FileCopyIcon />,
-			},
-			{
-				segment: "mempool-simulation",
-				title: "Mempool Simulation",
-				icon: <WaterIcon/>,
-			}
+            }
         ]
     },
     {
@@ -71,12 +59,7 @@ const NAVIGATION = [
                 segment: "query",
                 title: "Query",
                 icon: <ContentPasteSearchTwoToneIcon />,
-            },
-			{
-				segment: "coblockly",
-				title: "Compliance",
-				icon: <FactCheckIcon />,
-			}
+            }
         ]
     },
     {
@@ -92,7 +75,12 @@ const NAVIGATION = [
                 segment: "xes",
                 title: "XES",
                 icon: <PersonIcon />,
-            }
+            },
+			{
+				segment: "coblockly",
+				title: "CoBlockly",
+				icon: <FactCheckIcon />,
+			}
         ]
     },
 ];

--- a/src/api/services.js
+++ b/src/api/services.js
@@ -1,4 +1,3 @@
-import { continuousColorLegendClasses } from "@mui/x-charts";
 import axios from "axios";
 const serverUrl = "http://localhost:8000";
 
@@ -222,6 +221,88 @@ function findAllValuesByKey(obj, key) {
 
 }
 
+export const _ocelDetect = async (records) => {
+    try {
+        const response = await axios.post(serverUrl + "/api/ocel/detect", { records });
+        return { status: response.status, data: response.data };
+    } catch (error) {
+        console.error(error);
+        return { status: error?.response?.status, data: error?.response?.data };
+    }
+};
+
+export const _ocelBuild = async (records, nestedColNames, objectTypeCols, activityCol, timestampCol) => {
+    try {
+        const response = await axios.post(serverUrl + "/api/ocel/build", {
+            records, nestedColNames, objectTypeCols, activityCol, timestampCol
+        });
+        return { status: response.status, data: response.data };
+    } catch (error) {
+        console.error(error);
+        return { status: error?.response?.status, data: error?.response?.data };
+    }
+};
+
+export const _ocelE2OCombinations = async (sessionId) => {
+    try {
+        const response = await axios.post(serverUrl + "/api/ocel/e2o-combinations", { sessionId });
+        return { status: response.status, data: response.data };
+    } catch (error) {
+        return { status: error?.response?.status, data: error?.response?.data };
+    }
+};
+
+export const _ocelE2OQualifiers = async (sessionId, qualifierMap) => {
+    try {
+        const response = await axios.post(serverUrl + "/api/ocel/e2o-qualifiers", { sessionId, qualifierMap });
+        return { status: response.status, data: response.data };
+    } catch (error) {
+        return { status: error?.response?.status, data: error?.response?.data };
+    }
+};
+
+export const _ocelO2OEnrich = async (sessionId) => {
+    try {
+        const response = await axios.post(serverUrl + "/api/ocel/o2o-enrich", { sessionId });
+        return { status: response.status, data: response.data };
+    } catch (error) {
+        return { status: error?.response?.status, data: error?.response?.data };
+    }
+};
+
+export const _ocelO2OQualifiers = async (sessionId, qualifierMap) => {
+    try {
+        const response = await axios.post(serverUrl + "/api/ocel/o2o-qualifiers", { sessionId, qualifierMap });
+        return { status: response.status, data: response.data };
+    } catch (error) {
+        return { status: error?.response?.status, data: error?.response?.data };
+    }
+};
+
+export const _ocelGetSession = async (sessionId) => {
+    try {
+        const response = await axios.get(serverUrl + `/api/ocel/session/${sessionId}`);
+        return { status: response.status, data: response.data };
+    } catch (error) {
+        return { status: error?.response?.status, data: error?.response?.data };
+    }
+};
+
+export const _ocelDeleteSession = async (sessionId) => {
+    try {
+        await axios.delete(serverUrl + `/api/ocel/session/${sessionId}`);
+    } catch (_) {}
+};
+
+export const _ocelExport = async (sessionId, format) => {
+    try {
+        const response = await axios.get(serverUrl + `/api/ocel/export/${sessionId}/${format}`, { responseType: 'blob' });
+        return { status: response.status, data: response.data };
+    } catch (error) {
+        return { status: error?.response?.status, data: null };
+    }
+};
+
 export const getData = async ({ type, query}) => {
   try {
     console.log("[Service] Fetching data with type:", type, "and query:", query);
@@ -231,43 +312,6 @@ export const getData = async ({ type, query}) => {
     console.error(error)
     return {status: error.response.status, data: error.response.data}
   }
-}
-
-export const _simulateTransaction = async (payload) => {
-    try {
-        const response = await axios.post(serverUrl + "/api/simulate", payload);
-        return {status: response.status, data: response.data };
-    }
-    catch (error) {
-        console.error("Errore durante la simulazione: ", error);
-        return { status: error?.response?.status, data: error?.response?.data };
-    }
-}
-
-export const _getMempoolTxs = async (limit) => {
-    try {
-        const response = await axios.get(`${serverUrl}/api/get-mempool-txs`, {
-            params: { limit: limit }
-        });
-        return { status: response.status, data: response.data };
-    }
-    catch (err) {
-        console.error("Errore durante il ricevimento delle transazioni dalla mempool: ", err);
-        return { status: err?.response?.status, data: err?.response?.data };
-    }
-}
-
-export const _simulateMempoolTxs = async (payload) => {
-    try {
-        const response = await axios.post(serverUrl + "/api/simulate/mempool-txs", {
-            transactions: payload 
-        });
-        return { status: response.status, data: response.data };
-    }
-    catch (err) {
-        console.error("Errore durante la simulazione della mempool: ", err);
-        return { status: err?.response?.status, data: err?.response?.data };
-    }
 }
 
 

--- a/src/layouts/PageLayout.jsx
+++ b/src/layouts/PageLayout.jsx
@@ -28,7 +28,7 @@ const CardContentNoPadding = styled(CardContent)(
     `
 )
 
-const MAX_DISPLAY_SIZE = 49;
+const MAX_DISPLAY_SIZE = 49; // limit
 
 const limitJsonSize = (data) => {
     if (!data) return null;
@@ -94,6 +94,8 @@ function PageLayout({children, loading, setLoading}) {
 
 
     const path = window.location.pathname
+    const isOcelPage = path === '/data-mapping/ocel';
+    const isXesPage  = path === '/data-mapping/xes';
 
     const handleShowXes =() =>{
         setShowXes(!showXes)
@@ -201,8 +203,8 @@ function PageLayout({children, loading, setLoading}) {
     }
 
     const renderPageButtons=()=>{
-        switch(path){
-            case "/ocel":
+        switch(true){
+            case isOcelPage:
                 return(<Box display="flex" justifyContent="space-between" gap={2}>
                                         <Button component="label" variant="contained" startIcon={<FileUpload/>}
                                                 sx={{padding: 1, height: "55px"}}>
@@ -238,7 +240,7 @@ function PageLayout({children, loading, setLoading}) {
                                         </Button>
                                     </Box>
                 )
-            case "/xes":
+            case isXesPage:
                 return (<Box display="flex" justifyContent="space-between" gap={2}>
                                         <Button component="label" variant="contained" startIcon={<FileUpload/>}
                                                 sx={{padding: 1, height: "55px"}}>
@@ -292,52 +294,60 @@ function PageLayout({children, loading, setLoading}) {
                         <Card sx={{minWidth: "500px", height: "500px", backgroundColor: "#202020"}}>
                             <Box height="40px" display="flex" alignItems="center" justifyContent="space-between" padding={2}>
                                 <Typography variant="h5" color="#FFFFFF">Contract Logs</Typography>
-                                {path === "/ocel" && <Button variant="contained" sx={{padding: 1, width: "130px"}}
-                                         onClick={handleShowOcel}>{showOcel ? "Show Logs" : "Show OCEL"}</Button>}
-                                <Button disabled={!results} color="error"
+                                {isOcelPage && results && (
+                                    <Button variant="contained" sx={{padding: 1, width: "130px"}}
+                                        onClick={handleShowOcel}>{showOcel ? "Show OCEL" : "Show Logs"}</Button>
+                                )}
+                                {isOcelPage && (
+                                    <Button disabled={!ocel?.events?.length} color="error"
                                         onClick={handleDelete} sx={{padding: 0, '&.Mui-disabled': {color: 'rgba(255, 0, 0, 0.5)'}}}>
-                                    <Delete/>
-                                </Button>
-                                {path === "/xes" && <Button variant="contained" sx={{padding: 1, width: "130px"}}
-                                         onClick={handleShowXes}>{showXes ? "Show Logs" : "Show XES"}</Button>}
-                                <Button disabled={!results} color="error"
-                                        onClick={handleDeleteXes} sx={{padding: 0, '&.Mui-disabled': {color: 'rgba(255, 0, 0, 0.5)'}}}>
-                                    <Delete/>
-                                </Button>
+                                        <Delete/>
+                                    </Button>
+                                )}
+                                {isXesPage && (
+                                    <Button variant="contained" sx={{padding: 1, width: "130px"}}
+                                        onClick={handleShowXes}>{showXes ? "Show Logs" : "Show XES"}</Button>
+                                )}
+                                {!isOcelPage && !isXesPage && (
+                                    <Button disabled={!results} color="error"
+                                        onClick={handleDelete} sx={{padding: 0, '&.Mui-disabled': {color: 'rgba(255, 0, 0, 0.5)'}}}>
+                                        <Delete/>
+                                    </Button>
+                                )}
                             </Box>
                             <CardContentNoPadding sx={{ height: "calc(100% - 112px)", overflowY: "auto", overflowX: "auto", whiteSpace: "pre", overflow: "auto"}}>
                                 {
-                                     loading ? (
+                                    loading ? (
                                         <Box width="100%" height="100%" display="flex" justifyContent="center" alignItems="center">
                                             <CircularProgress />
                                         </Box>
-                                    ) : showOcel ? (
-                                        <JsonView value={ocel} style={{ ...darkTheme, fontSize: '14px' }} width="100%" />
+                                    ) : isOcelPage ? (
+                                        // sulla pagina OCEL: mostra OCEL di default, logs solo se richiesto
+                                        showOcel && results ? (
+                                            <JsonView value={limitJsonSize(results)} style={{ ...darkTheme, fontSize: '14px' }} width="100%" />
+                                        ) : ocel?.events?.length ? (
+                                            <JsonView value={limitJsonSize(ocel)} style={{ ...darkTheme, fontSize: '14px' }} width="100%" />
+                                        ) : null
                                     ) : showXes ? (
                                         <Box sx={{
                                             width: "100%",
                                             maxWidth: "100%",
-                                            overflowX: "auto",  // Enables horizontal scrolling
-                                            whiteSpace: "pre",  // Ensures text does not wrap
-                                            backgroundColor: "#1e1e1e", // Optional: Dark theme background
+                                            overflowX: "auto",
+                                            whiteSpace: "pre",
+                                            backgroundColor: "#1e1e1e",
                                             padding: 2
                                         }}>
-                                            <Box sx={{
-                                                display: "inline-block",  // Ensures the box takes the exact width of the XML content
-                                                minWidth: "100%"  // Prevents shrinking
-                                            }}>
+                                            <Box sx={{ display: "inline-block", minWidth: "100%" }}>
                                                 <XMLViewer xml={xes.xesString || "<empty></empty>"} />
                                             </Box>
                                         </Box>
                                     ) : results && (
-                                        <JsonView value={results} style={{ ...darkTheme, fontSize: '14px' }} width="100%" />
+                                        <JsonView value={limitJsonSize(results)} style={{ ...darkTheme, fontSize: '14px' }} width="100%" />
                                     )
                                 }
                             </CardContentNoPadding>
                         </Card>
-                        {
-                            renderPageButtons()
-                        }
+                        {!isOcelPage && renderPageButtons()}
                     </Stack>
                 </Grid>
             </Grid>

--- a/src/pages/OcelMapping.jsx
+++ b/src/pages/OcelMapping.jsx
@@ -1,101 +1,598 @@
-import React, {useState} from 'react';
-import {Box, Button, Stack, Typography} from "@mui/material";
-import AddBoxIcon from '@mui/icons-material/AddBox';
-
-import CustomTypography from "../components/CustomTypography";
-import ObjectType from "../components/objectTypes/ObjectType";
-import PageLayout from "../layouts/PageLayout";
-import ActivityEventType from "../components/eventTypes/ActivityEventType";
-import useDataContext from "../context/useDataContext";
-import {_occelMapping} from "../api/services";
+import React, { useState, useRef } from 'react';
+import {
+    Alert, Box, Button, Chip, Divider, FormControl, IconButton,
+    InputLabel, MenuItem, Select, Stack, TextField, Typography
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+import UploadFileIcon from '@mui/icons-material/UploadFile';
+import PageLayout from '../layouts/PageLayout';
+import useDataContext from '../context/useDataContext';
+import {
+    _ocelDetect, _ocelBuild,
+    _ocelE2OCombinations, _ocelE2OQualifiers,
+    _ocelO2OEnrich, _ocelO2OQualifiers,
+    _ocelGetSession, _ocelDeleteSession, _ocelExport,
+} from '../api/services';
 
 function OcelMapping() {
+    const { setOcel } = useDataContext();
+    const fileInputRef = useRef();
 
-    const {results} = useDataContext();
+    const [step, setStep] = useState('upload');
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
 
-    const [loading, setLoading] = useState(false)
+    // file & detection
+    const [records, setRecords] = useState(null);
+    const [fileName, setFileName] = useState('');
+    const [nestedCols, setNestedCols] = useState([]);
+    const [flatCols, setFlatCols] = useState([]);
+    const [normalizedColumns, setNormalizedColumns] = useState({});
 
-    const [objectsTypesItem, setObjectsTypesItem] = useState([])
+    // config selections
+    const [selectedNesteds, setSelectedNesteds] = useState([]);
+    const [selectedObjectTypes, setSelectedObjectTypes] = useState([]);
+    const [activityCol, setActivityCol] = useState('activity');
+    const [timestampCol, setTimestampCol] = useState('timestamp');
 
-    const [objectTypesToMap, setObjectTypesToMap] = useState([])
+    // phase 2 result
+    const [stats, setStats] = useState(null);
+    const [normalizedRows, setNormalizedRows] = useState(0);
+    const [ocelData, setOcelData] = useState(null); // copia locale per download fase 2 e Contract Logs
+    const [sessionId, setSessionId] = useState(null);
 
-    const {setOcel} = useDataContext()
+    // phase 3a — E2O rules: [{ activity, objectType, qualifier }]
+    const [e2oCombinations, setE2OCombinations] = useState([]);
+    const [e2oRules, setE2ORules] = useState([]);
 
-    const handleAddObjectType = () => {
-        setObjectsTypesItem([...objectsTypesItem, {name: "", names: []}])
-    }
+    // phase 3b/c — O2O rules: [{ type1, type2, qualifier }]
+    const [o2oPairs, setO2OPairs] = useState([]);
+    const [o2oDistinctTypes, setO2ODistinctTypes] = useState([]);
+    const [o2oRules, setO2ORules] = useState([]);
+    const [o2oCount, setO2OCount] = useState(null);
 
-    const sendObjectTypesToMap = () => {
-        setLoading(true)
-        _occelMapping(objectTypesToMap, results).then((response) => {
-            setOcel(response.data)
-            setLoading(false)
-        })
-    }
+    // ── file upload ─────────────────────────────────────────────────────────────
+
+    const handleFileChange = async (e) => {
+        const file = e.target.files[0];
+        if (!file) return;
+        setError(null);
+        setLoading(true);
+        try {
+            const text = await file.text();
+            const parsed = JSON.parse(text);
+            const arr = Array.isArray(parsed) ? parsed : Object.values(parsed);
+            const filtered = arr.filter(r => Object.keys(r).length > 0);
+            setRecords(filtered);
+            setFileName(file.name);
+
+            const res = await _ocelDetect(filtered);
+            if (res.status !== 200) throw new Error(res.data?.error || 'Column detection failed');
+
+            setNestedCols(res.data.nested);
+            setFlatCols(res.data.flat);
+            setNormalizedColumns(res.data.normalizedColumns || {});
+            setSelectedNesteds([]);
+            setSelectedObjectTypes([]);
+
+            const eventCandidates = ['activity', 'functionName', 'method', 'action', 'eventName'];
+            setActivityCol(eventCandidates.find(c => res.data.flat.includes(c)) || res.data.flat[0] || 'activity');
+
+            const tsCandidates = ['timestamp', 'timeStamp', 'time', 'blockTimestamp', 'date'];
+            setTimestampCol(tsCandidates.find(c => res.data.flat.includes(c)) || 'timestamp');
+
+            setStep('config');
+        } catch (err) {
+            setError(err.message);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    // ── config helpers ───────────────────────────────────────────────────────────
+
+    const toggleNested = (col) =>
+        setSelectedNesteds(prev => prev.includes(col) ? prev.filter(c => c !== col) : [...prev, col]);
+
+    const toggleObjectType = (col) =>
+        setSelectedObjectTypes(prev => prev.includes(col) ? prev.filter(c => c !== col) : [...prev, col]);
+
+    const objectTypeOptions = [
+        ...selectedNesteds.flatMap(n => normalizedColumns[n] || []),
+        ...flatCols.filter(c => c !== activityCol && c !== timestampCol),
+    ];
+
+    // ── build (phase 2) ──────────────────────────────────────────────────────────
+
+    const handleBuild = async () => {
+        if (!selectedNesteds.length || !selectedObjectTypes.length) return;
+        setLoading(true);
+        setError(null);
+        try {
+            const res = await _ocelBuild(records, selectedNesteds, selectedObjectTypes, activityCol, timestampCol);
+            if (res.status !== 200) throw new Error(res.data?.error || 'OCEL build failed');
+            setStats(res.data.stats);
+            setNormalizedRows(res.data.normalizedRows);
+            setOcel(res.data.ocel);
+            setOcelData(res.data.ocel); // tenuto solo per download fase 2 e Contract Logs
+            setSessionId(res.data.sessionId);
+            setStep('result');
+        } catch (err) {
+            setError(err.message);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    // ── phase 3a setup ───────────────────────────────────────────────────────────
+
+    const handleGoToFase3 = async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const res = await _ocelE2OCombinations(sessionId);
+            if (res.status !== 200) throw new Error(res.data?.error || 'E2O combinations failed');
+            setE2OCombinations(res.data.combinations);
+            setE2ORules([]);
+            setStep('e2oQual');
+        } catch (err) {
+            setError(err.message);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    // ── E2O rule helpers ─────────────────────────────────────────────────────────
+
+    const e2oActivities = [...new Set(e2oCombinations.map(c => c.activity))];
+    const e2oObjectTypes = [...new Set(e2oCombinations.map(c => c.objectType))];
+
+    const addE2ORule = () =>
+        setE2ORules(prev => [...prev, { activity: e2oActivities[0] || '', objectType: e2oObjectTypes[0] || '', qualifier: '' }]);
+
+    const updateE2ORule = (i, field, value) =>
+        setE2ORules(prev => prev.map((r, idx) => idx === i ? { ...r, [field]: value } : r));
+
+    const removeE2ORule = (i) =>
+        setE2ORules(prev => prev.filter((_, idx) => idx !== i));
+
+    const handleApplyE2O = async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const qualifierMap = {};
+            for (const r of e2oRules) {
+                if (r.qualifier.trim()) qualifierMap[`${r.objectType}|${r.activity}`] = r.qualifier.trim();
+            }
+            const res = await _ocelE2OQualifiers(sessionId, qualifierMap);
+            if (res.status !== 200) throw new Error(res.data?.error || 'E2O qualifiers failed');
+            setStats(res.data.stats);
+
+            const enrichRes = await _ocelO2OEnrich(sessionId);
+            if (enrichRes.status !== 200) throw new Error(enrichRes.data?.error || 'O2O enrichment failed');
+            setO2OPairs(enrichRes.data.pairs);
+
+            // tipi distinti: derivati dalle combinations già caricate
+            const types = [...new Set(e2oCombinations.map(c => c.objectType))];
+            setO2ODistinctTypes(types);
+            setO2ORules([]);
+            setStep('o2oQual');
+        } catch (err) {
+            setError(err.message);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    // ── O2O rule helpers ─────────────────────────────────────────────────────────
+
+    const addO2ORule = () =>
+        setO2ORules(prev => [...prev, { type1: o2oDistinctTypes[0] || '', type2: o2oDistinctTypes[1] || o2oDistinctTypes[0] || '', qualifier: '' }]);
+
+    const updateO2ORule = (i, field, value) =>
+        setO2ORules(prev => prev.map((r, idx) => idx === i ? { ...r, [field]: value } : r));
+
+    const removeO2ORule = (i) =>
+        setO2ORules(prev => prev.filter((_, idx) => idx !== i));
+
+    const handleApplyO2O = async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            // risolvi tipo di ogni coppia dalle combinations (non serve più ocelData.objects)
+            const objTypeMap = {};
+            for (const c of e2oCombinations) {
+                // le combinations hanno objectType ma non i singoli oid:
+                // usiamo ocelData (snapshot fase 2) per la mappa id→type
+            }
+            for (const obj of (ocelData?.objects ?? [])) objTypeMap[obj.id] = obj.type;
+
+            const qualifierMap = {};
+            for (const pair of o2oPairs) {
+                const t1 = objTypeMap[pair.oid] || '';
+                const t2 = objTypeMap[pair.oid_2] || '';
+                const rule = o2oRules.find(r => r.type1 === t1 && r.type2 === t2);
+                if (rule && rule.qualifier.trim()) {
+                    qualifierMap[`${pair.oid}|${pair.oid_2}`] = rule.qualifier.trim();
+                }
+            }
+            const res = await _ocelO2OQualifiers(sessionId, qualifierMap);
+            if (res.status !== 200) throw new Error(res.data?.error || 'O2O qualifiers failed');
+            setO2OCount(res.data.o2oCount);
+
+            // recupera OCEL finale dalla sessione per aggiornare il Contract Logs panel
+            const finalRes = await _ocelGetSession(sessionId);
+            if (finalRes.status === 200) {
+                setOcel(finalRes.data.ocel);
+                setOcelData(finalRes.data.ocel);
+            }
+            setStep('done');
+        } catch (err) {
+            setError(err.message);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    // ── download ─────────────────────────────────────────────────────────────────
+
+    const triggerDownload = (blob, filename) => {
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        a.click();
+        URL.revokeObjectURL(url);
+    };
+
+    // Fase 2: scarica snapshot locale (OCEL non ancora modificato dalla fase 3)
+    const handleDownloadPhase2 = () => {
+        if (!ocelData) return;
+        const blob = new Blob([JSON.stringify(ocelData, null, 2)], { type: 'application/json' });
+        const baseName = fileName.replace(/\.json$/i, '');
+        triggerDownload(blob, `ocel_${baseName}_phase2.json`);
+    };
+
+    // Fase 3+: scarica dalla sessione nel formato scelto via endpoint /api/ocel/export
+    const handleExport = async (format) => {
+        if (!sessionId) return;
+        const res = await _ocelExport(sessionId, format);
+        if (!res.data) return;
+        const baseName = fileName.replace(/\.json$/i, '');
+        const ext = format === 'csv' ? 'csv' : format === 'jsonocel' ? 'jsonocel' : 'json';
+        triggerDownload(res.data, `ocel_${baseName}.${ext}`);
+    };
+
+    // ── reset ────────────────────────────────────────────────────────────────────
+
+    const reset = () => {
+        if (sessionId) _ocelDeleteSession(sessionId);
+        setStep('upload');
+        setRecords(null); setFileName(''); setStats(null); setOcelData(null); setError(null);
+        setSessionId(null);
+        setSelectedNesteds([]); setSelectedObjectTypes([]);
+        setE2OCombinations([]); setE2ORules([]);
+        setO2OPairs([]); setO2ODistinctTypes([]); setO2ORules([]); setO2OCount(null);
+        if (fileInputRef.current) fileInputRef.current.value = '';
+    };
+
+    // ── render ───────────────────────────────────────────────────────────────────
 
     return (
         <PageLayout loading={loading}>
-            <Box display="flex" justifyContent="center">
-                <Box position="relative" height="100%" width={520} paddingBottom={2}>
-                    <Typography variant="h3">
-                        Data Mapping
+            <Box display="flex" justifyContent="center" paddingTop={4}>
+                <Box width={640}>
+                    <Typography variant="h4" gutterBottom>OCEL Mapping</Typography>
+                    <Typography variant="body2" color="text.secondary" mb={3}>
+                        Phase 1 (normalization) → Phase 2 (OCEL 2.0) → Phase 3 (Qualifiers)
                     </Typography>
-                    <Stack marginY={3} height="calc(100vh - 300px)" overflow="auto">
-                        <CustomTypography>
-                            {"{"}
-                        </CustomTypography>
-                        <CustomTypography>
-                            &nbsp;&nbsp;&nbsp;"eventTypes": [
-                        </CustomTypography>
-                        <ActivityEventType/>
-                        <CustomTypography>
-                            &nbsp;&nbsp;&nbsp;],
-                        </CustomTypography>
-                        <CustomTypography>
-                            &nbsp;&nbsp;&nbsp;"objectTypes": [
-                            {
-                                <Button onClick={handleAddObjectType}>
-                                    <AddBoxIcon sx={{fontSize: 30}}/>
-                                </Button>
-                            }
-                            {objectsTypesItem.length === 0 && "],"}
-                        </CustomTypography>
-                        {objectsTypesItem.length > 0 &&
-                            (
+
+                    {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+
+                    {/* ── Upload ── */}
+                    {step === 'upload' && (
+                        <Box>
+                            <Typography variant="body1" mb={3}>
+                                Upload a JSON file of blockchain transactions.
+                            </Typography>
+                            <input ref={fileInputRef} type="file" accept=".json" hidden onChange={handleFileChange} />
+                            <Button variant="contained" size="large" startIcon={<UploadFileIcon />}
+                                onClick={() => fileInputRef.current.click()}>
+                                Upload JSON file
+                            </Button>
+                        </Box>
+                    )}
+
+                    {/* ── Config ── */}
+                    {step === 'config' && (
+                        <Box>
+                            <Alert severity="success" sx={{ mb: 3 }}>
+                                <strong>{fileName}</strong> — {records.length} transactions
+                            </Alert>
+
+                            {/* Nested columns */}
+                            <Typography variant="subtitle1" fontWeight="bold" mb={1}>Nested columns</Typography>
+                            <Stack direction="row" spacing={1} mb={3} flexWrap="wrap">
+                                {nestedCols.map(c => (
+                                    <Chip key={c} label={c}
+                                        color={selectedNesteds.includes(c) ? 'primary' : 'default'}
+                                        onClick={() => toggleNested(c)} sx={{ mb: 1 }} />
+                                ))}
+                                {nestedCols.length === 0 && (
+                                    <Typography variant="body2" color="text.secondary">No nested columns detected</Typography>
+                                )}
+                            </Stack>
+
+                            {/* Event column */}
+                            <Typography variant="subtitle1" fontWeight="bold" mb={1}>Event column</Typography>
+                            <Stack direction="row" spacing={1} mb={2} flexWrap="wrap">
+                                {flatCols.map(c => (
+                                    <Chip key={c} label={c} size="small"
+                                        color={activityCol === c ? 'success' : 'default'}
+                                        onClick={() => setActivityCol(c)} sx={{ mb: 1 }} />
+                                ))}
+                            </Stack>
+
+                            {/* Timestamp column */}
+                            <Typography variant="subtitle1" fontWeight="bold" mb={1}>Timestamp column</Typography>
+                            <Stack direction="row" spacing={1} mb={3} flexWrap="wrap">
+                                {flatCols.map(c => (
+                                    <Chip key={c} label={c} size="small"
+                                        color={timestampCol === c ? 'success' : 'default'}
+                                        onClick={() => setTimestampCol(c)} sx={{ mb: 1 }} />
+                                ))}
+                            </Stack>
+
+                            <Divider sx={{ mb: 3 }} />
+
+                            {/* Object type columns */}
+                            <Typography variant="subtitle1" fontWeight="bold" mb={0.5}>Object type columns</Typography>
+                            <Typography variant="body2" color="text.secondary" mb={2}>
+                                Select columns containing Ethereum addresses. Multiple selection allowed.
+                            </Typography>
+
+                            {selectedNesteds.length > 0 && (
                                 <>
-                                    {objectsTypesItem.map((objectType, index) => (
-                                        <ObjectType key={`${index}_object`}
-                                                    objectTypesToMap={objectTypesToMap}
-                                                    setObjectTypesToMap={setObjectTypesToMap}
-                                                    setObjectsTypesItem={setObjectsTypesItem}
-                                                    objectsTypesItem={objectsTypesItem} objectType={objectType}
-                                                    index={index}/>
-                                    ))}
-                                    <CustomTypography>
-                                        &nbsp;&nbsp;&nbsp;],
-                                    </CustomTypography>
+                                    <Typography variant="caption" color="text.secondary" mb={0.5} display="block">
+                                        From nested: <strong>{selectedNesteds.join(', ')}</strong>
+                                    </Typography>
+                                    <Stack direction="row" spacing={1} mb={1.5} flexWrap="wrap">
+                                        {selectedNesteds.flatMap(n => normalizedColumns[n] || []).map(c => (
+                                            <Chip key={c} label={c}
+                                                color={selectedObjectTypes.includes(c) ? 'secondary' : 'default'}
+                                                onClick={() => toggleObjectType(c)} sx={{ mb: 1 }} />
+                                        ))}
+                                    </Stack>
                                 </>
-                            )
-                        }
-                        <CustomTypography>
-                            &nbsp;&nbsp;&nbsp;"events": []
-                        </CustomTypography>
-                        <CustomTypography>
-                            &nbsp;&nbsp;&nbsp;"objects": []
-                        </CustomTypography>
-                        <CustomTypography>
-                            {"}"}
-                        </CustomTypography>
-                    </Stack>
+                            )}
+
+                            <Typography variant="caption" color="text.secondary" mb={0.5} display="block">Flat columns</Typography>
+                            <Stack direction="row" spacing={1} mb={1} flexWrap="wrap">
+                                {flatCols.filter(c => c !== activityCol && c !== timestampCol).map(c => (
+                                    <Chip key={c} label={c}
+                                        color={selectedObjectTypes.includes(c) ? 'secondary' : 'default'}
+                                        onClick={() => toggleObjectType(c)} sx={{ mb: 1 }} />
+                                ))}
+                            </Stack>
+
+                            {selectedObjectTypes.length > 0 && (
+                                <Typography variant="body2" color="text.secondary" mb={2}>
+                                    Selected: {selectedObjectTypes.join(', ')}
+                                </Typography>
+                            )}
+
+                            <Stack direction="row" spacing={2} mt={2}>
+                                <Button variant="outlined" onClick={reset}>Change file</Button>
+                                <Button variant="contained"
+                                    disabled={!selectedNesteds.length || !selectedObjectTypes.length}
+                                    onClick={handleBuild}>
+                                    Build OCEL
+                                </Button>
+                            </Stack>
+                        </Box>
+                    )}
+
+                    {/* ── Phase 2 Result ── */}
+                    {step === 'result' && stats && (
+                        <Box>
+                            <Alert severity="success" sx={{ mb: 3 }}>OCEL Phase 2 built successfully</Alert>
+
+                            <Stack spacing={1.5} mb={3}>
+                                {[
+                                    ['Transactions loaded', records.length],
+                                    ['Rows after normalization', normalizedRows],
+                                    ['OCEL events', stats.events],
+                                    ['Unique objects', stats.objects],
+                                    ['E2O relations', stats.relations],
+                                ].map(([label, value]) => (
+                                    <Box key={label} display="flex" justifyContent="space-between" borderBottom="1px solid #eee" pb={1}>
+                                        <Typography color="text.secondary">{label}</Typography>
+                                        <Typography fontWeight="bold">{value}</Typography>
+                                    </Box>
+                                ))}
+                            </Stack>
+
+                            <Box mb={2}>
+                                <Typography variant="body2" color="text.secondary" mb={1}>Event Types</Typography>
+                                <Stack direction="row" spacing={1} flexWrap="wrap">
+                                    {stats.eventTypes.map(t => <Chip key={t} label={t} size="small" sx={{ mb: 1 }} />)}
+                                </Stack>
+                            </Box>
+
+                            <Box mb={3}>
+                                <Typography variant="body2" color="text.secondary" mb={1}>Object Types</Typography>
+                                <Stack direction="row" spacing={1} flexWrap="wrap">
+                                    {stats.objectTypes.map(t => <Chip key={t} label={t} size="small" sx={{ mb: 1 }} />)}
+                                </Stack>
+                            </Box>
+
+                            <Stack direction="row" spacing={2}>
+                                <Button variant="outlined" onClick={reset}>Change file</Button>
+                                <Button variant="outlined" onClick={handleDownloadPhase2}>Download JSON</Button>
+                                <Button variant="contained" onClick={handleGoToFase3}>Configure Phase 3</Button>
+                            </Stack>
+                        </Box>
+                    )}
+
+                    {/* ── Phase 3a — E2O Qualifiers ── */}
+                    {step === 'e2oQual' && (
+                        <Box>
+                            <Typography variant="h6" gutterBottom>Phase 3a — E2O Qualifiers</Typography>
+                            <Typography variant="body2" color="text.secondary" mb={3}>
+                                Define qualifier rules for event → object relationships. Relations without a matching rule keep an empty qualifier.
+                            </Typography>
+
+                            <Stack spacing={2} mb={2}>
+                                {e2oRules.map((rule, i) => (
+                                    <Box key={i} display="flex" alignItems="center" gap={1.5}>
+                                        <FormControl size="small" sx={{ minWidth: 160 }}>
+                                            <InputLabel>Event</InputLabel>
+                                            <Select value={rule.activity} label="Event"
+                                                onChange={e => updateE2ORule(i, 'activity', e.target.value)}>
+                                                {e2oActivities.map(a => <MenuItem key={a} value={a}>{a}</MenuItem>)}
+                                            </Select>
+                                        </FormControl>
+
+                                        <Typography variant="body2" color="text.secondary">→</Typography>
+
+                                        <FormControl size="small" sx={{ minWidth: 180 }}>
+                                            <InputLabel>Object</InputLabel>
+                                            <Select value={rule.objectType} label="Object"
+                                                onChange={e => updateE2ORule(i, 'objectType', e.target.value)}>
+                                                {e2oObjectTypes.map(t => <MenuItem key={t} value={t}>{t}</MenuItem>)}
+                                            </Select>
+                                        </FormControl>
+
+                                        <TextField size="small" label="Qualifier"
+                                            placeholder='e.g. "spender"'
+                                            value={rule.qualifier}
+                                            onChange={e => updateE2ORule(i, 'qualifier', e.target.value)}
+                                            sx={{ flex: 1 }} />
+
+                                        <IconButton size="small" onClick={() => removeE2ORule(i)}>
+                                            <DeleteIcon fontSize="small" />
+                                        </IconButton>
+                                    </Box>
+                                ))}
+                            </Stack>
+
+                            <Button startIcon={<AddIcon />} onClick={addE2ORule} sx={{ mb: 3 }}>
+                                Add rule
+                            </Button>
+
+                            <Stack direction="row" spacing={2}>
+                                <Button variant="outlined" onClick={() => setStep('result')}>Back</Button>
+                                <Button variant="outlined" onClick={handleDownloadPhase2}>Download JSON (Phase 2)</Button>
+                                <Button variant="contained" onClick={handleApplyE2O}>Apply & go to O2O</Button>
+                            </Stack>
+                        </Box>
+                    )}
+
+                    {/* ── Phase 3b/c — O2O Qualifiers ── */}
+                    {step === 'o2oQual' && (
+                        <Box>
+                            <Typography variant="h6" gutterBottom>Phase 3b/c — O2O Enrichment + Qualifiers</Typography>
+                            <Typography variant="body2" color="text.secondary" mb={1}>
+                                O2O pairs generated: <strong>{o2oPairs.length}</strong>
+                            </Typography>
+                            <Typography variant="body2" color="text.secondary" mb={3}>
+                                Define qualifier rules for object → object relationships. Pairs without a matching rule will be removed.
+                            </Typography>
+
+                            {o2oPairs.length === 0 ? (
+                                <Alert severity="info" sx={{ mb: 2 }}>
+                                    No O2O pairs generated. Select at least 2 object types to generate pairs.
+                                </Alert>
+                            ) : (
+                                <>
+                                    <Stack spacing={2} mb={2}>
+                                        {o2oRules.map((rule, i) => (
+                                            <Box key={i} display="flex" alignItems="center" gap={1.5}>
+                                                <FormControl size="small" sx={{ minWidth: 160 }}>
+                                                    <InputLabel>Object type 1</InputLabel>
+                                                    <Select value={rule.type1} label="Object type 1"
+                                                        onChange={e => updateO2ORule(i, 'type1', e.target.value)}>
+                                                        {o2oDistinctTypes.map(t => <MenuItem key={t} value={t}>{t}</MenuItem>)}
+                                                    </Select>
+                                                </FormControl>
+
+                                                <Typography variant="body2" color="text.secondary">→</Typography>
+
+                                                <FormControl size="small" sx={{ minWidth: 160 }}>
+                                                    <InputLabel>Object type 2</InputLabel>
+                                                    <Select value={rule.type2} label="Object type 2"
+                                                        onChange={e => updateO2ORule(i, 'type2', e.target.value)}>
+                                                        {o2oDistinctTypes.map(t => <MenuItem key={t} value={t}>{t}</MenuItem>)}
+                                                    </Select>
+                                                </FormControl>
+
+                                                <TextField size="small" label="Qualifier"
+                                                    placeholder='e.g. "approves"'
+                                                    value={rule.qualifier}
+                                                    onChange={e => updateO2ORule(i, 'qualifier', e.target.value)}
+                                                    sx={{ flex: 1 }} />
+
+                                                <IconButton size="small" onClick={() => removeO2ORule(i)}>
+                                                    <DeleteIcon fontSize="small" />
+                                                </IconButton>
+                                            </Box>
+                                        ))}
+                                    </Stack>
+
+                                    <Button startIcon={<AddIcon />} onClick={addO2ORule} sx={{ mb: 3 }}>
+                                        Add rule
+                                    </Button>
+                                </>
+                            )}
+
+                            <Stack direction="row" spacing={2}>
+                                <Button variant="outlined" onClick={() => setStep('e2oQual')}>Back</Button>
+                                <Button variant="outlined" onClick={() => handleExport('json')}>Download JSON (Phase 3a)</Button>
+                                <Button variant="contained" onClick={handleApplyO2O}>Apply O2O Qualifiers</Button>
+                            </Stack>
+                        </Box>
+                    )}
+
+                    {/* ── Done ── */}
+                    {step === 'done' && (
+                        <Box>
+                            <Alert severity="success" sx={{ mb: 3 }}>Phase 3 pipeline completed</Alert>
+
+                            <Stack spacing={1.5} mb={3}>
+                                {[
+                                    ['OCEL events', stats?.events],
+                                    ['Unique objects', stats?.objects],
+                                    ['E2O relations (with qualifier)', stats?.relations],
+                                    ['O2O pairs (with qualifier)', o2oCount],
+                                ].map(([label, value]) => (
+                                    <Box key={label} display="flex" justifyContent="space-between" borderBottom="1px solid #eee" pb={1}>
+                                        <Typography color="text.secondary">{label}</Typography>
+                                        <Typography fontWeight="bold">{value ?? '—'}</Typography>
+                                    </Box>
+                                ))}
+                            </Stack>
+
+                            <Stack direction="row" spacing={2} flexWrap="wrap">
+                                <Button variant="outlined" onClick={reset}>Load another file</Button>
+                                <Button variant="contained" onClick={() => handleExport('json')}>
+                                    Download JSON
+                                </Button>
+                                <Button variant="contained" onClick={() => handleExport('jsonocel')}
+                                    sx={{ backgroundColor: '#5316ec', '&:hover': { backgroundColor: '#3d0fb5' } }}>
+                                    Download JSONOCEL
+                                </Button>
+                                <Button variant="contained" onClick={() => handleExport('csv')}
+                                    sx={{ backgroundColor: '#38a651', '&:hover': { backgroundColor: '#2f6749' } }}>
+                                    Download CSV
+                                </Button>
+                            </Stack>
+                        </Box>
+                    )}
                 </Box>
             </Box>
-            <Box display="flex" justifyContent="center">
-                <Button disabled={objectTypesToMap.length === 0 || !results} component="label" variant="contained" onClick={sendObjectTypesToMap} sx={{padding: 1}}>
-                    Map Data
-                </Button>
-            </Box>
         </PageLayout>
-    )
+    );
 }
 
 export default OcelMapping;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,78 @@
+let idValue = ""
+export const findValue = (obj, key, array) => {
+    if (obj.hasOwnProperty("txHash")) {
+        idValue = obj["txHash"]
+    }
+    if (obj.hasOwnProperty(key)) {
+        array.push({id: idValue, value: obj[key]})
+        return obj[key]
+    } else {
+        for (let k in obj) {
+            if (Array.isArray(obj[k])) {
+                obj[k].forEach(item => {
+                    if (typeof item === "object" && item !== null) {
+                        const result = findValue(item, key, array)
+                        if (result) {
+                            return result
+                        }
+                    }
+                })
+            } else if (typeof obj[k] === "object" && obj[k] !== null) {
+                const result = findValue(obj[k], key, array)
+                if (result) {
+                    return result
+                }
+            }
+        }
+    }
+}
+
+export const findUnixTime = (obj) => {
+    if (obj.hasOwnProperty("txHash")) {
+        idValue = obj["txHash"]
+    }
+    for (let key in obj) {
+        if (Array.isArray(obj[key])) {
+            obj[key].forEach(item => {
+                if (typeof item === "object" && item !== null) {
+                    findUnixTime(item)
+                } else if(typeof item === "string") {
+                    if (obj[key].includes("T") && obj[key].includes(".000Z")) {
+                        return {id: idValue, time: obj[key]}
+                    }
+                }
+            })
+        } else if (typeof obj[key] === "object" && obj[key] !== null) {
+            findUnixTime(obj[key])
+        } else if (typeof obj[key] === "string") {
+            if (obj[key].includes("T") && obj[key].includes(".000Z")) {
+                return {id: idValue, time: obj[key]}
+            }
+        }
+    }
+}
+
+export const findRelatedKeys = (obj, key, array) => {
+    let keys = []
+    if (obj.hasOwnProperty(key)) {
+        Object.keys(obj).forEach(key => array.push(key))
+        return keys
+    } else {
+        for (let k in obj) {
+            if (Array.isArray(obj[k])) {
+                const item = obj[k][0]
+                if (typeof item === "object" && item !== null) {
+                    const result = findRelatedKeys(item, key, array)
+                    if (result) {
+                        return result
+                    }
+                }
+            } else if (typeof obj[k] === "object" && obj[k] !== null) {
+                const result = findRelatedKeys(obj[k], key, array)
+                if (result) {
+                    return result
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds the OCEL Mapping page to the frontend, implementing a full
wizard-based UI for transforming blockchain transaction logs into OCEL 2.0
process logs.

## Changes

- **`src/pages/OcelMapping.jsx`** — multi-step wizard covering the complete
  pipeline: JSON upload, nested column detection, object type selection,
  E2O qualifier assignment, O2O enrichment and qualifier assignment,
  and final export
- **`src/api/services.js`** — API calls for all OCEL endpoints: detect,
  build, e2o-combinations, e2o-qualifiers, o2o-enrich, o2o-qualifiers,
  session read/delete, and export (JSON, JSONOCEL, CSV)
- **`src/App.jsx`** — added route for the new OCEL Mapping page
- **`src/layouts/PageLayout.jsx`** — added navigation support for the
  OCEL Mapping page
- **`src/utils.js`** — shared utility functions
- **`package.json`** — added required dependencies

## How it works

The UI guides the user through 5 phases that mirror the backend pipeline:
1. Upload a blockchain transaction log (JSON)
2. Detect nested columns and normalize the data
3. Build the OCEL 2.0 structure (events, objects, E2O relations)
4. Assign E2O and O2O qualifiers via dropdown menus
5. Download the result as OCEL 2.0 JSON, JSONOCEL, or flat CSV

All intermediate state is managed server-side via a session ID returned
after phase 2, so no large payloads are transferred between steps.
